### PR TITLE
解决taro3.3.x报错addEventListener is not a function的问题

### DIFF
--- a/src/echarts-taro3-react/ec-canvas/echarts.js
+++ b/src/echarts-taro3-react/ec-canvas/echarts.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) : typeof define === 'function' && define.amd ? define(['exports'], factory) : factory(global.echarts = {});
-})(this, function (exports) {
+})(this, function (exports,window,document) {
   'use strict';
   /*
   * Licensed to the Apache Software Foundation (ASF) under one
@@ -7497,6 +7497,7 @@
   };
 
   Pattern.prototype.getCanvasPattern = function (ctx) {
+    console.log("ctx",ctx)
     return ctx.createPattern(this.image, this.repeat || 'repeat');
   };
   /**


### PR DESCRIPTION
issue#9914 https://github.com/NervJS/taro/issues/9914 解决taro3.3.x报错addEventListener is not a function的问题